### PR TITLE
Implement base Seer's Enchanting Table

### DIFF
--- a/src/main/java/com/nuggylib/enchantmentsseer/common/block/SeersEnchantingTableBlock.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/block/SeersEnchantingTableBlock.java
@@ -1,0 +1,38 @@
+package com.nuggylib.enchantmentsseer.common.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.ContainerBlock;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.shapes.ISelectionContext;
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.world.IBlockReader;
+import org.jetbrains.annotations.Nullable;
+import net.minecraft.block.EnchantingTableBlock;
+
+/**
+ * Basically a modified version of {@link EnchantingTableBlock}
+ */
+public class SeersEnchantingTableBlock extends ContainerBlock {
+
+    protected static final VoxelShape SHAPE = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 12.0D, 16.0D);
+
+    public SeersEnchantingTableBlock(Properties properties) {
+        super(properties);
+    }
+
+    public boolean useShapeForLightOcclusion(BlockState state) {
+        return true;
+    }
+
+    public VoxelShape getShape(BlockState state, IBlockReader reader, BlockPos blockPos, ISelectionContext context) {
+        return SHAPE;
+    }
+
+    @Nullable
+    @Override
+    public TileEntity newBlockEntity(IBlockReader reader) {
+        return null;
+    }
+}

--- a/src/main/java/com/nuggylib/enchantmentsseer/common/registries/EnchantmentsSeerBlocks.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/registries/EnchantmentsSeerBlocks.java
@@ -1,17 +1,15 @@
 package com.nuggylib.enchantmentsseer.common.registries;
 
 import com.nuggylib.enchantmentsseer.common.EnchantmentsSeer;
+import com.nuggylib.enchantmentsseer.common.block.SeersEnchantingTableBlock;
+import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
+import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
-/**
- * Block registy class
- *
- * Based on the Mekanism codebase
- *
- * @see "https://github.com/mekanism/Mekanism/blob/v10.1/src/main/java/mekanism/common/registries/MekanismBlocks.java"
- */
 public class EnchantmentsSeerBlocks {
 
     private EnchantmentsSeerBlocks() {
@@ -20,6 +18,6 @@ public class EnchantmentsSeerBlocks {
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, EnchantmentsSeer.MOD_ID);
 
     // Blocks
-//    public static final BlockRegistryObject<BlockTile<TileEntitySeersEnchantmentTable, BlockTypeTile<TileEntitySeersEnchantmentTable>>, ItemBlockEnchantmentsSeer> SEERS_ENCHANTING_TABLE = BLOCKS.register("seers_enchanting_table", () -> new BlockTile<>(EnchantmentsSeerBlockTypes.SEERS_ENCHANTING_TABLE), ItemBlockSeersEnchantingTable::new);
+    public static final RegistryObject<Block> SEERS_ENCHANTING_TABLE = BLOCKS.register("seers_enchanting_table", () -> new SeersEnchantingTableBlock(AbstractBlock.Properties.of(Material.STONE, MaterialColor.COLOR_BLACK)));
 
 }

--- a/src/main/java/com/nuggylib/enchantmentsseer/common/registries/EnchantmentsSeerItems.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/registries/EnchantmentsSeerItems.java
@@ -7,6 +7,9 @@ import com.nuggylib.enchantmentsseer.common.item.ItemSeersManuscript;
 import com.nuggylib.enchantmentsseer.common.item.ItemSeersStone;
 import com.nuggylib.enchantmentsseer.common.item.ItemSeersStoneU;
 import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.registries.DeferredRegister;
@@ -23,10 +26,12 @@ public class EnchantmentsSeerItems {
 
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, EnchantmentsSeer.MOD_ID);
 
+    // Item
     public static final RegistryObject<Item> SEERS_STONE = ITEMS.register("seers_stone", () -> new ItemSeersStone(new Item.Properties().tab(EnchantmentsSeer.tabEnchantmentsSeer)));
     public static final RegistryObject<Item> SEERS_STONE_UNCHARGED = ITEMS.register("seers_stone_uncharged", () -> new ItemSeersStoneU(new Item.Properties().tab(EnchantmentsSeer.tabEnchantmentsSeer)));
     public static final RegistryObject<Item> SEERS_MANUSCRIPT = ITEMS.register("seers_manuscript", () -> new ItemSeersManuscript(new Item.Properties().tab(EnchantmentsSeer.tabEnchantmentsSeer)));
     public static final RegistryObject<Item> SEERS_ENCHANTED_PAGE = ITEMS.register("seers_enchanted_page", () -> new ItemSeersEnchantedPage(new Item.Properties().tab(EnchantmentsSeer.tabEnchantmentsSeer)));
 
-
+    // BlockItem
+    public static final RegistryObject<Item> SEERS_ENCHANTING_TABLE = ITEMS.register("seers_enchanting_table", () -> new BlockItem(EnchantmentsSeerBlocks.SEERS_ENCHANTING_TABLE.get(), new Item.Properties().tab(EnchantmentsSeer.tabEnchantmentsSeer)));
 }

--- a/src/main/java/com/nuggylib/enchantmentsseer/common/tile/SeersEnchantingTableTileEntity.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/tile/SeersEnchantingTableTileEntity.java
@@ -1,0 +1,50 @@
+package com.nuggylib.enchantmentsseer.common.tile;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityType;
+import net.minecraftforge.items.IItemHandler;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @see "https://mcforge.readthedocs.io/en/1.16.x/datastorage/capabilities/#forge-provided-capabilities"
+ */
+public class SeersEnchantingTableTileEntity extends TileEntity implements IItemHandler {
+
+    public SeersEnchantingTableTileEntity(TileEntityType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public int getSlots() {
+        return 0;
+    }
+
+    @NotNull
+    @Override
+    public ItemStack getStackInSlot(int slot) {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public ItemStack extractItem(int slot, int amount, boolean simulate) {
+        return null;
+    }
+
+    @Override
+    public int getSlotLimit(int slot) {
+        return 0;
+    }
+
+    @Override
+    public boolean isItemValid(int slot, @NotNull ItemStack stack) {
+        return false;
+    }
+}


### PR DESCRIPTION
# Description
Adds (and registers) the base classes needed to create the Seer's Enchanting table. The texture does not currently render (which is expected). Here is what the block currently looks like:
![2021-09-10_00 39 26](https://user-images.githubusercontent.com/14364659/132805608-c464e7c7-359c-46a6-a8c6-0cbabea11dc1.png)

## Notes
* Registry names **can** be repeated, so long as they are in separate registries
    * For example, `seers_enchanting_table` is the string name used for the registry name for both the block and item representation of the Seer's Enchanting Table - _this is ideal since they also share textures and need to use the same assets_
 