### PR TITLE
Register TE Type and fix block render

### DIFF
--- a/src/main/java/com/nuggylib/enchantmentsseer/common/block/SeersEnchantingTableBlock.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/block/SeersEnchantingTableBlock.java
@@ -1,15 +1,18 @@
 package com.nuggylib.enchantmentsseer.common.block;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.ContainerBlock;
+import com.nuggylib.enchantmentsseer.common.tile.SeersEnchantingTableTileEntity;
+import net.minecraft.block.*;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.pathfinding.PathType;
+import net.minecraft.tileentity.EnchantingTableTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
+import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
-import net.minecraft.block.EnchantingTableBlock;
 
 /**
  * Basically a modified version of {@link EnchantingTableBlock}
@@ -22,10 +25,12 @@ public class SeersEnchantingTableBlock extends ContainerBlock {
         super(properties);
     }
 
+    @Override
     public boolean useShapeForLightOcclusion(BlockState state) {
         return true;
     }
 
+    @Override
     public VoxelShape getShape(BlockState state, IBlockReader reader, BlockPos blockPos, ISelectionContext context) {
         return SHAPE;
     }
@@ -33,6 +38,28 @@ public class SeersEnchantingTableBlock extends ContainerBlock {
     @Nullable
     @Override
     public TileEntity newBlockEntity(IBlockReader reader) {
-        return null;
+        return new SeersEnchantingTableTileEntity();
     }
+
+    @Override
+    public BlockRenderType getRenderShape(BlockState blockState) {
+        return BlockRenderType.MODEL;
+    }
+
+    @Override
+    public void setPlacedBy(World worldIn, BlockPos blockPos, BlockState blockState, LivingEntity livingEntity, ItemStack itemStack) {
+        if (itemStack.hasCustomHoverName()) {
+            TileEntity tileentity = worldIn.getBlockEntity(blockPos);
+            if (tileentity instanceof EnchantingTableTileEntity) {
+                ((EnchantingTableTileEntity)tileentity).setCustomName(itemStack.getHoverName());
+            }
+        }
+
+    }
+
+    @Override
+    public boolean isPathfindable(BlockState blockState, IBlockReader reader, BlockPos blockPos, PathType pathType) {
+        return false;
+    }
+
 }

--- a/src/main/java/com/nuggylib/enchantmentsseer/common/registries/EnchantmentsSeerTileEntityTypes.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/registries/EnchantmentsSeerTileEntityTypes.java
@@ -1,9 +1,14 @@
 package com.nuggylib.enchantmentsseer.common.registries;
 
+import com.nuggylib.enchantmentsseer.common.EnchantmentsSeer;
+import com.nuggylib.enchantmentsseer.common.tile.SeersEnchantingTableTileEntity;
+import net.minecraft.tileentity.TileEntityType;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
 /**
- * Inspired by the Mekanism codebase
- *
- * @see "https://github.com/mekanism/Mekanism/blob/v10.1/src/main/java/mekanism/common/registries/MekanismTileEntityTypes.java"
+ * @see "https://mcforge.readthedocs.io/en/latest/tileentities/tileentity/#creating-a-tileentity"
  */
 public class EnchantmentsSeerTileEntityTypes {
 
@@ -11,8 +16,8 @@ public class EnchantmentsSeerTileEntityTypes {
 
     }
 
-//    public static final TileEntityTypeDeferredRegister TILE_ENTITY_TYPES = new TileEntityTypeDeferredRegister(EnchantmentsSeer.MOD_ID);
-//
-//    public static final TileEntityTypeRegistryObject<TileEntitySeersEnchantmentTable> SEERS_ENCHANTING_TABLE = TILE_ENTITY_TYPES.register(EnchantmentsSeerBlocks.SEERS_ENCHANTING_TABLE, TileEntitySeersEnchantmentTable::new);
+    public static final DeferredRegister<TileEntityType<?>> TILE_ENTITY_TYPES = DeferredRegister.create(ForgeRegistries.TILE_ENTITIES, EnchantmentsSeer.MOD_ID);
+
+    public static final RegistryObject<TileEntityType<SeersEnchantingTableTileEntity>> SEERS_ENCHANTING_TABLE = TILE_ENTITY_TYPES.register("seers_enchanting_table", () -> TileEntityType.Builder.of(SeersEnchantingTableTileEntity::new, EnchantmentsSeerBlocks.SEERS_ENCHANTING_TABLE.get()).build(null));
 
 }

--- a/src/main/java/com/nuggylib/enchantmentsseer/common/tile/SeersEnchantingTableTileEntity.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/tile/SeersEnchantingTableTileEntity.java
@@ -1,18 +1,22 @@
 package com.nuggylib.enchantmentsseer.common.tile;
 
+import com.nuggylib.enchantmentsseer.common.registries.EnchantmentsSeerTileEntityTypes;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
+import net.minecraft.tileentity.EnchantingTableTileEntity;
 
 /**
+ * Our version of the {@link EnchantingTableTileEntity}
+ *
  * @see "https://mcforge.readthedocs.io/en/1.16.x/datastorage/capabilities/#forge-provided-capabilities"
  */
 public class SeersEnchantingTableTileEntity extends TileEntity implements IItemHandler {
 
-    public SeersEnchantingTableTileEntity(TileEntityType<?> type) {
-        super(type);
+    public SeersEnchantingTableTileEntity() {
+        super(EnchantmentsSeerTileEntityTypes.SEERS_ENCHANTING_TABLE.get());
     }
 
     @Override


### PR DESCRIPTION
# Description
This PR just fixes the rendering for the Seer's Enchanting table so that now the texture applies appropriately (no more invisible box)!

Additionally, I added logic to register a `TileEntityType<SeersEnchantingTableTileEntity>` object. However, this is not currently in use (though, we will need it basically immediately).

Here's how the table looks now:
![2021-09-10_02 26 36](https://user-images.githubusercontent.com/14364659/132816763-bb8a661f-4d5b-4943-8b43-994c3b42adbd.png)
