### PR TITLE
Complete base implementation for Seer's Enchanting Table

### DIFF
--- a/src/main/java/com/nuggylib/enchantmentsseer/client/ClientRegistration.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/client/ClientRegistration.java
@@ -1,6 +1,9 @@
 package com.nuggylib.enchantmentsseer.client;
 
+import com.nuggylib.enchantmentsseer.client.gui.SeersEnchantingTableScreen;
 import com.nuggylib.enchantmentsseer.common.EnchantmentsSeer;
+import com.nuggylib.enchantmentsseer.common.registries.EnchantmentsSeerContainerTypes;
+import net.minecraft.client.gui.ScreenManager;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ModelBakeEvent;
@@ -20,7 +23,7 @@ public class ClientRegistration {
 
     @SubscribeEvent
     public static void registerContainers(RegistryEvent.Register<ContainerType<?>> event) {
-
+        ScreenManager.register(EnchantmentsSeerContainerTypes.SEERS_ENCHANTING_TABLE.get(), SeersEnchantingTableScreen::new);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/nuggylib/enchantmentsseer/client/gui/SeersEnchantingTableScreen.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/client/gui/SeersEnchantingTableScreen.java
@@ -1,0 +1,226 @@
+package com.nuggylib.enchantmentsseer.client.gui;
+
+import com.google.common.collect.Lists;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.IVertexBuilder;
+import com.nuggylib.enchantmentsseer.common.inventory.container.SeersEnchantingTableContainer;
+import net.minecraft.client.gui.screen.EnchantmentScreen;
+import net.minecraft.client.gui.screen.inventory.ContainerScreen;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.entity.model.BookModel;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnchantmentNameParts;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.vector.Matrix4f;
+import net.minecraft.util.math.vector.Vector3f;
+import net.minecraft.util.text.*;
+
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Our version of the base {@link EnchantmentScreen}
+ */
+public class SeersEnchantingTableScreen extends ContainerScreen<SeersEnchantingTableContainer> {
+
+    private static final ResourceLocation ENCHANTING_TABLE_LOCATION = new ResourceLocation("minecraft:textures/gui/container/enchanting_table.png");
+    private static final ResourceLocation ENCHANTING_BOOK_LOCATION = new ResourceLocation("minecraft:textures/entity/enchanting_table_book.png");
+    private static final BookModel BOOK_MODEL = new BookModel();
+    private final Random random = new Random();
+    public int time;
+    public float flip;
+    public float oFlip;
+    public float flipT;
+    public float flipA;
+    public float open;
+    public float oOpen;
+    private ItemStack last = ItemStack.EMPTY;
+
+    public SeersEnchantingTableScreen(SeersEnchantingTableContainer container, PlayerInventory inv, ITextComponent title) {
+        super(container, inv, title);
+    }
+
+    public void tick() {
+        super.tick();
+        this.tickBook();
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        // TODO: Modify this logic - the vanilla code assumes there will only be three elements to populate - our
+        //  GUI will be different (we won't know how many there will be until an enchant item is added)
+        //int i = (this.width - this.imageWidth) / 2;
+        //int j = (this.height - this.imageHeight) / 2;
+
+        //for(int k = 0; k < 3; ++k) {
+        //    double d0 = mouseX - (double)(i + 60);
+        //    double d1 = mouseY - (double)(j + 14 + 19 * k);
+        //    if (d0 >= 0.0D && d1 >= 0.0D && d0 < 108.0D && d1 < 19.0D && this.menu.clickMenuButton(this.minecraft.player, k)) {
+        //        this.minecraft.gameMode.handleInventoryButtonClick((this.menu).containerId, k);
+        //        return true;
+        //    }
+        //}
+        return super.mouseClicked(mouseX, mouseY, button);
+    }
+
+    @Override
+    protected void renderBg(MatrixStack matrix, float partialTick, int mouseX, int mouseY) {
+        RenderHelper.setupForFlatItems();
+        RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
+        this.minecraft.getTextureManager().bind(ENCHANTING_TABLE_LOCATION);
+        int i = (this.width - this.imageWidth) / 2;
+        int j = (this.height - this.imageHeight) / 2;
+        this.blit(matrix, i, j, 0, 0, this.imageWidth, this.imageHeight);
+        RenderSystem.matrixMode(5889);
+        RenderSystem.pushMatrix();
+        RenderSystem.loadIdentity();
+        int k = (int)this.minecraft.getWindow().getGuiScale();
+        RenderSystem.viewport((this.width - 320) / 2 * k, (this.height - 240) / 2 * k, 320 * k, 240 * k);
+        RenderSystem.translatef(-0.34F, 0.23F, 0.0F);
+        RenderSystem.multMatrix(Matrix4f.perspective(90.0D, 1.3333334F, 9.0F, 80.0F));
+        RenderSystem.matrixMode(5888);
+        matrix.pushPose();
+        MatrixStack.Entry matrixstack$entry = matrix.last();
+        matrixstack$entry.pose().setIdentity();
+        matrixstack$entry.normal().setIdentity();
+        matrix.translate(0.0D, (double)3.3F, 1984.0D);
+        matrix.scale(5.0F, 5.0F, 5.0F);
+        matrix.mulPose(Vector3f.ZP.rotationDegrees(180.0F));
+        matrix.mulPose(Vector3f.XP.rotationDegrees(20.0F));
+        float f1 = MathHelper.lerp(partialTick, this.oOpen, this.open);
+        matrix.translate((double)((1.0F - f1) * 0.2F), (double)((1.0F - f1) * 0.1F), (double)((1.0F - f1) * 0.25F));
+        float f2 = -(1.0F - f1) * 90.0F - 90.0F;
+        matrix.mulPose(Vector3f.YP.rotationDegrees(f2));
+        matrix.mulPose(Vector3f.XP.rotationDegrees(180.0F));
+        float f3 = MathHelper.lerp(partialTick, this.oFlip, this.flip) + 0.25F;
+        float f4 = MathHelper.lerp(partialTick, this.oFlip, this.flip) + 0.75F;
+        f3 = (f3 - (float)MathHelper.fastFloor((double)f3)) * 1.6F - 0.3F;
+        f4 = (f4 - (float)MathHelper.fastFloor((double)f4)) * 1.6F - 0.3F;
+        if (f3 < 0.0F) {
+            f3 = 0.0F;
+        }
+
+        if (f4 < 0.0F) {
+            f4 = 0.0F;
+        }
+
+        if (f3 > 1.0F) {
+            f3 = 1.0F;
+        }
+
+        if (f4 > 1.0F) {
+            f4 = 1.0F;
+        }
+
+        RenderSystem.enableRescaleNormal();
+        BOOK_MODEL.setupAnim(0.0F, f3, f4, f1);
+        IRenderTypeBuffer.Impl irendertypebuffer$impl = IRenderTypeBuffer.immediate(Tessellator.getInstance().getBuilder());
+        IVertexBuilder ivertexbuilder = irendertypebuffer$impl.getBuffer(BOOK_MODEL.renderType(ENCHANTING_BOOK_LOCATION));
+        BOOK_MODEL.renderToBuffer(matrix, ivertexbuilder, 15728880, OverlayTexture.NO_OVERLAY, 1.0F, 1.0F, 1.0F, 1.0F);
+        irendertypebuffer$impl.endBatch();
+        matrix.popPose();
+        RenderSystem.matrixMode(5889);
+        RenderSystem.viewport(0, 0, this.minecraft.getWindow().getWidth(), this.minecraft.getWindow().getHeight());
+        RenderSystem.popMatrix();
+        RenderSystem.matrixMode(5888);
+        RenderHelper.setupFor3DItems();
+        RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
+        int goldCost = 0;
+
+        for(int i1 = 0; i1 < 3; ++i1) {
+            int j1 = i + 60;
+            int k1 = j1 + 20;
+            this.setBlitOffset(0);
+            this.minecraft.getTextureManager().bind(ENCHANTING_TABLE_LOCATION);
+            int cost = 0;
+            RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
+            if (cost == 0) {
+                this.blit(matrix, j1, j + 14 + 19 * i1, 0, 185, 108, 19);
+            } else {
+                String s = "" + cost;
+                int i2 = 86 - this.font.width(s);
+                ITextProperties itextproperties = EnchantmentNameParts.getInstance().getRandomName(this.font, i2);
+                int j2 = 6839882;
+                if (((goldCost < i1 + 1 || this.minecraft.player.experienceLevel < cost) && !this.minecraft.player.abilities.instabuild)) { // Forge: render buttons as disabled when enchantable but enchantability not met on lower levels
+                    this.blit(matrix, j1, j + 14 + 19 * i1, 0, 185, 108, 19);
+                    this.blit(matrix, j1 + 1, j + 15 + 19 * i1, 16 * i1, 239, 16, 16);
+                    this.font.drawWordWrap(itextproperties, k1, j + 16 + 19 * i1, i2, (j2 & 16711422) >> 1);
+                    j2 = 4226832;
+                } else {
+                    int k2 = mouseX - (i + 60);
+                    int l2 = mouseY - (j + 14 + 19 * i1);
+                    if (k2 >= 0 && l2 >= 0 && k2 < 108 && l2 < 19) {
+                        this.blit(matrix, j1, j + 14 + 19 * i1, 0, 204, 108, 19);
+                        j2 = 16777088;
+                    } else {
+                        this.blit(matrix, j1, j + 14 + 19 * i1, 0, 166, 108, 19);
+                    }
+
+                    this.blit(matrix, j1 + 1, j + 15 + 19 * i1, 16 * i1, 223, 16, 16);
+                    this.font.drawWordWrap(itextproperties, k1, j + 16 + 19 * i1, i2, j2);
+                    j2 = 8453920;
+                }
+
+                this.font.drawShadow(matrix, s, (float)(k1 + 86 - this.font.width(s)), (float)(j + 16 + 19 * i1 + 7), j2);
+            }
+        }
+
+    }
+
+    @Override
+    public void render(MatrixStack matrix, int mouseX, int mouseY, float partialTicks) {
+        partialTicks = this.minecraft.getFrameTime();
+        this.renderBackground(matrix);
+        super.render(matrix, mouseX, mouseY, partialTicks);
+        this.renderTooltip(matrix, mouseX, mouseY);
+    }
+
+    /**
+     * Book flip animation logic for the book displayed in the GUI
+     */
+    public void tickBook() {
+        ItemStack itemstack = this.menu.getSlot(0).getItem();
+        if (!ItemStack.matches(itemstack, this.last)) {
+            this.last = itemstack;
+
+            do {
+                this.flipT += (float)(this.random.nextInt(4) - this.random.nextInt(4));
+            } while(this.flip <= this.flipT + 1.0F && this.flip >= this.flipT - 1.0F);
+        }
+
+        ++this.time;
+        this.oFlip = this.flip;
+        this.oOpen = this.open;
+        boolean displayingEnchantments = false;
+
+        // TODO: Modify this logic so that it sets displayingEnchantments to true when there are enchantments to
+        //  display in the GUI. Vanilla logic does by checking not only if there are enchantments, but also if any of
+        //  the listed enchantments has a non-zero cost
+//        for(int i = 0; i < 3; ++i) {
+//            if ((this.menu).costs[i] != 0) {
+//                displayingEnchantments = true;
+//            }
+//        }
+
+        if (displayingEnchantments) {
+            this.open += 0.2F;
+        } else {
+            this.open -= 0.2F;
+        }
+
+        this.open = MathHelper.clamp(this.open, 0.0F, 1.0F);
+        float f1 = (this.flipT - this.flip) * 0.4F;
+        float f = 0.2F;
+        f1 = MathHelper.clamp(f1, -0.2F, 0.2F);
+        this.flipA += (f1 - this.flipA) * 0.9F;
+        this.flip += this.flipA;
+    }
+
+}

--- a/src/main/java/com/nuggylib/enchantmentsseer/common/EnchantmentsSeer.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/EnchantmentsSeer.java
@@ -18,7 +18,9 @@
 package com.nuggylib.enchantmentsseer.common;
 
 import com.nuggylib.enchantmentsseer.common.registries.EnchantmentsSeerBlocks;
+import com.nuggylib.enchantmentsseer.common.registries.EnchantmentsSeerContainerTypes;
 import com.nuggylib.enchantmentsseer.common.registries.EnchantmentsSeerItems;
+import com.nuggylib.enchantmentsseer.common.registries.EnchantmentsSeerTileEntityTypes;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.apache.logging.log4j.LogManager;
@@ -47,9 +49,8 @@ public class EnchantmentsSeer
         instance = this;
         EnchantmentsSeerItems.ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
         EnchantmentsSeerBlocks.BLOCKS.register(FMLJavaModLoadingContext.get().getModEventBus());
-        // TODO Figure out an easier way (than Mekanism) to register these types
-//        EnchantmentsSeerTileEntityTypes.TILE_ENTITY_TYPES.register(FMLJavaModLoadingContext.get().getModEventBus());
-//        EnchantmentsSeerContainerTypes.CONTAINER_TYPES.register(FMLJavaModLoadingContext.get().getModEventBus());
+        EnchantmentsSeerTileEntityTypes.TILE_ENTITY_TYPES.register(FMLJavaModLoadingContext.get().getModEventBus());
+        EnchantmentsSeerContainerTypes.CONTAINER_TYPES.register(FMLJavaModLoadingContext.get().getModEventBus());
     }
 
 }

--- a/src/main/java/com/nuggylib/enchantmentsseer/common/EnchantmentsSeerEnchantHelper.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/EnchantmentsSeerEnchantHelper.java
@@ -1,0 +1,48 @@
+package com.nuggylib.enchantmentsseer.common;
+
+import com.google.common.collect.Lists;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentData;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.util.registry.Registry;
+
+import java.util.List;
+
+/**
+ * Helper class to perform enchantment-related tasks.
+ *
+ * This class is loosely-based off of {@link EnchantmentHelper} and provides similar functionality with slightly-altered
+ * behavior.
+ */
+public class EnchantmentsSeerEnchantHelper {
+
+    /**
+     * Get all enchantments for the given item stack
+     *
+     * This method is similar to {@link EnchantmentHelper#getAvailableEnchantmentResults(int, ItemStack, boolean)}, except
+     * that we don't care about level cost. We simply want to get <b>all</b> possible enchantments for the given item.
+     *
+     * @param itemStack             The item to get enchantments for
+     * @param simulate              TODO: we need to figure out what this is used for (maybe testing?)
+     * @return                      The list of compatible enchantments for the given {@link ItemStack}
+     */
+    public static List<Enchantment> getAvailableEnchantmentResults(ItemStack itemStack, boolean simulate) {
+        List<Enchantment> list = Lists.newArrayList();
+        boolean isBookItem = itemStack.getItem() == Items.BOOK;
+
+        // TODO: Add a way to "hook in" to other enchantment registries as well - as of now, this will only look for vanilla enchantments
+        for(Enchantment enchantment : Registry.ENCHANTMENT) {
+            if ((!enchantment.isTreasureOnly() || simulate) && enchantment.isDiscoverable() && (enchantment.canApplyAtEnchantingTable(itemStack) || (isBookItem && enchantment.isAllowedOnBooks()))) {
+                for(int i = enchantment.getMaxLevel(); i > enchantment.getMinLevel() - 1; --i) {
+                    list.add(enchantment);
+                }
+            }
+        }
+
+        return list;
+    }
+
+}

--- a/src/main/java/com/nuggylib/enchantmentsseer/common/block/SeersEnchantingTableBlock.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/block/SeersEnchantingTableBlock.java
@@ -1,15 +1,26 @@
 package com.nuggylib.enchantmentsseer.common.block;
 
+import com.nuggylib.enchantmentsseer.common.inventory.container.SeersEnchantingTableContainer;
 import com.nuggylib.enchantmentsseer.common.tile.SeersEnchantingTableTileEntity;
 import net.minecraft.block.*;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.container.EnchantmentContainer;
+import net.minecraft.inventory.container.INamedContainerProvider;
+import net.minecraft.inventory.container.SimpleNamedContainerProvider;
 import net.minecraft.item.ItemStack;
 import net.minecraft.pathfinding.PathType;
 import net.minecraft.tileentity.EnchantingTableTileEntity;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Hand;
+import net.minecraft.util.INameable;
+import net.minecraft.util.IWorldPosCallable;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
@@ -39,6 +50,29 @@ public class SeersEnchantingTableBlock extends ContainerBlock {
     @Override
     public TileEntity newBlockEntity(IBlockReader reader) {
         return new SeersEnchantingTableTileEntity();
+    }
+
+    @Override
+    public ActionResultType use(BlockState blockState, World worldIn, BlockPos blockPos, PlayerEntity player, Hand hand, BlockRayTraceResult rayTraceResult) {
+        if (worldIn.isClientSide) {
+            return ActionResultType.SUCCESS;
+        } else {
+            player.openMenu(blockState.getMenuProvider(worldIn, blockPos));
+            return ActionResultType.CONSUME;
+        }
+    }
+
+    @Nullable
+    public INamedContainerProvider getMenuProvider(BlockState blockState, World worldIn, BlockPos blockPos) {
+        TileEntity tileentity = worldIn.getBlockEntity(blockPos);
+        if (tileentity instanceof SeersEnchantingTableTileEntity) {
+            ITextComponent itextcomponent = ((INameable)tileentity).getDisplayName();
+            return new SimpleNamedContainerProvider((containerId, inv, player) -> {
+                return new SeersEnchantingTableContainer(containerId, IWorldPosCallable.create(worldIn, blockPos), inv);
+            }, itextcomponent);
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/src/main/java/com/nuggylib/enchantmentsseer/common/inventory/container/SeersEnchantingTableContainer.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/inventory/container/SeersEnchantingTableContainer.java
@@ -1,0 +1,267 @@
+package com.nuggylib.enchantmentsseer.common.inventory.container;
+
+import com.nuggylib.enchantmentsseer.common.EnchantmentsSeer;
+import com.nuggylib.enchantmentsseer.common.EnchantmentsSeerEnchantHelper;
+import com.nuggylib.enchantmentsseer.common.registries.EnchantmentsSeerBlocks;
+import com.nuggylib.enchantmentsseer.common.registries.EnchantmentsSeerContainerTypes;
+import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentData;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.container.Container;
+import net.minecraft.inventory.container.EnchantmentContainer;
+import net.minecraft.inventory.container.Slot;
+import net.minecraft.item.EnchantedBookItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.stats.Stats;
+import net.minecraft.util.IWorldPosCallable;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvents;
+import net.minecraftforge.common.Tags;
+
+import java.util.List;
+
+// TODO: Set this up to mimic the vanilla container class
+/**
+ * Our version of {@link EnchantmentContainer}
+ *
+ * An implementation of the {@link Container} class is required for any block that needs to store one or more
+ * {@link ItemStack}s.
+ */
+public class SeersEnchantingTableContainer extends Container {
+
+    // TODO: Explore/document this more
+    /**
+     * Unsure of what this is at the moment - it appears to be responsible for performing operations in the game
+     * world on behalf of the corresponding container.
+     *
+     * From observing how {@link EnchantmentContainer} uses this field, it appears that {@link IWorldPosCallable} provides
+     * a means through which you can perform container operations that require their interactions to also be synced
+     * to the server side. However, I'm still working to understand this better.
+     */
+    private final IWorldPosCallable access;
+
+    /**
+     * The slots for the container
+     *
+     * This DOES NOT have anything to do with the GUI slot textures. It simply declares that this container has two
+     * inventory slots, enabling it to store two separate {@link ItemStack}s.
+     */
+    private final IInventory enchantSlots = new Inventory(2) {
+        public void setChanged() {
+            super.setChanged();
+            SeersEnchantingTableContainer.this.slotsChanged(this);
+        }
+    };
+
+    /**
+     * Overloaded constructor
+     *
+     * This constructor is reponsible for "informing" the GUI where the slots belong on the texture, once rendered.
+     */
+    public SeersEnchantingTableContainer(int containerId, IWorldPosCallable access, PlayerInventory inv) {
+        super(EnchantmentsSeerContainerTypes.SEERS_ENCHANTING_TABLE.get(), containerId);
+        this.access = access;
+
+        // Create the enchant item slot
+        this.addSlot(new Slot(this.enchantSlots, 0, 15, 47) {
+            public boolean mayPlace(ItemStack potentialEnchantItem) {
+                return true;
+            }
+
+            public int getMaxStackSize() {
+                return 1;
+            }
+        });
+
+        // Create the reagent slot
+        this.addSlot(new Slot(this.enchantSlots, 1, 35, 47) {
+            public boolean mayPlace(ItemStack potentialReagentItem) {
+                return Tags.Items.GEMS_LAPIS.contains(potentialReagentItem.getItem());
+            }
+        });
+
+        // Create slots for the main inventory
+        for(int mainInventoryRow = 0; mainInventoryRow < 3; ++mainInventoryRow) {
+            for(int mainInventoryColumn = 0; mainInventoryColumn < 9; ++mainInventoryColumn) {
+                this.addSlot(new Slot(inv, mainInventoryColumn + mainInventoryRow * 9 + 9, 8 + mainInventoryColumn * 18, 84 + mainInventoryRow * 18));
+            }
+        }
+
+        // Create slots for the hotbar
+        for(int hotbarColumn = 0; hotbarColumn < 9; ++hotbarColumn) {
+            this.addSlot(new Slot(inv, hotbarColumn, 8 + hotbarColumn * 18, 142));
+        }
+    }
+
+    /**
+     * The "primary" constructor
+     *
+     * This constructor is used when registering the class
+     */
+    public SeersEnchantingTableContainer(int containerId, PlayerInventory playerInventory) {
+        // TODO: Find out what impact IWorldPosCallable.NULL has
+        this(containerId, IWorldPosCallable.NULL, playerInventory);
+    }
+
+    // TODO: Clarify the docs for this once we know more about it
+    /**
+     * Determines if <b>something</b> is still valid, but existing documentation doesn't make it very clear.
+     *
+     * This implementation mimics the functionality for the same method in {@link EnchantmentContainer}
+     */
+    @Override
+    public boolean stillValid(PlayerEntity player) {
+        return stillValid(this.access, player, EnchantmentsSeerBlocks.SEERS_ENCHANTING_TABLE.get());
+    }
+
+    /**
+     * Runs when the contents of the inventory change
+     *
+     * {@link Container#slotsChanged(IInventory)} is invoked anytime a player modifies the contents of the given container,
+     * which makes it a very good place to perform key operations such as obtaining the list of enchantments for the item
+     * currently in the first slot.
+     */
+    @Override
+    public void slotsChanged(IInventory inv) {
+        if (inv == this.enchantSlots) {
+            ItemStack stack = inv.getItem(0);
+            if (!stack.isEmpty() && stack.isEnchantable()) {
+                // Unlike Vanilla, we don't use any concept of "power level" for enchanting - as a result, our table doesn't need
+                // bookshelves around it (since those are directly-used to determine the power level)
+                this.access.execute((worldIn, blockPos) -> {
+                    List<Enchantment> list = EnchantmentsSeerEnchantHelper.getAvailableEnchantmentResults(stack, false);
+
+                    for (Enchantment enchantment : list) {
+                        EnchantmentsSeer.logger.info(String.format("%s", enchantment.getFullname(enchantment.getMaxLevel())));
+                    }
+                    this.broadcastChanges();
+                });
+            }
+        }
+
+    }
+
+    @Override
+    public boolean clickMenuButton(PlayerEntity player, int cost) {
+        ItemStack enchantItemStack = this.enchantSlots.getItem(0);
+        ItemStack reagentItemStack = this.enchantSlots.getItem(1);
+        int reagentCost = cost + 1;
+        if ((reagentItemStack.isEmpty() || reagentItemStack.getCount() < reagentCost) && !player.abilities.instabuild) {
+            return false;
+        } else if (enchantItemStack.isEmpty() || !player.abilities.instabuild) {
+            return false;
+        } else {
+            this.access.execute((worldIn, blockPos) -> {
+                ItemStack resultItemStack = enchantItemStack;
+                List<Enchantment> list = EnchantmentsSeerEnchantHelper.getAvailableEnchantmentResults(enchantItemStack, false);
+                if (!list.isEmpty()) {
+                    player.onEnchantmentPerformed(enchantItemStack, reagentCost);
+                    boolean isBookItem = enchantItemStack.getItem() == Items.BOOK;
+                    if (isBookItem) {
+                        resultItemStack = new ItemStack(Items.ENCHANTED_BOOK);
+                        CompoundNBT compoundnbt = enchantItemStack.getTag();
+                        if (compoundnbt != null) {
+                            resultItemStack.setTag(compoundnbt.copy());
+                        }
+
+                        this.enchantSlots.setItem(0, resultItemStack);
+                    }
+
+                    for(int j = 0; j < list.size(); ++j) {
+                        Enchantment enchantmentdata = list.get(j);  // TODO: Use this in the enchantment process (or
+                        // Disallow books from being enchanted for the sake of simplicity
+                        if (!isBookItem) {
+                            // TODO: Modify the logic here so that the USER sets the enchantment level
+                            //resultItemStack.enchant(enchantmentdata.enchantment, enchantmentdata.level);
+                        }
+                    }
+
+                    if (!player.abilities.instabuild) {
+                        reagentItemStack.shrink(reagentCost);
+                        if (reagentItemStack.isEmpty()) {
+                            this.enchantSlots.setItem(1, ItemStack.EMPTY);
+                        }
+                    }
+
+                    player.awardStat(Stats.ENCHANT_ITEM);
+                    if (player instanceof ServerPlayerEntity) {
+                        CriteriaTriggers.ENCHANTED_ITEM.trigger((ServerPlayerEntity)player, resultItemStack, reagentCost);
+                    }
+
+                    this.enchantSlots.setChanged();
+                    this.slotsChanged(this.enchantSlots);
+                    worldIn.playSound((PlayerEntity)null, blockPos, SoundEvents.ENCHANTMENT_TABLE_USE, SoundCategory.BLOCKS, 1.0F, worldIn.random.nextFloat() * 0.1F + 0.9F);
+                }
+
+            });
+            return true;
+        }
+    }
+
+    @Override
+    public void removed(PlayerEntity player) {
+        super.removed(player);
+        this.access.execute((worldIn, blockPos) -> {
+            this.clearContainer(player, player.level, this.enchantSlots);
+        });
+    }
+
+    /**
+     * This method is invoked whenever the player "quick moves" an item into the Seers Enchanting Table.
+     *
+     * To quick-move an {@link ItemStack}, simply hold the <pre>SHIFT</pre> key and click the item to quick-move.
+     */
+    @Override
+    public ItemStack quickMoveStack(PlayerEntity player, int slotIndex) {
+        ItemStack holderItemStack = ItemStack.EMPTY;
+        Slot slot = this.slots.get(slotIndex);
+        if (slot != null && slot.hasItem()) {
+            ItemStack itemStackInSlot = slot.getItem();
+            holderItemStack = itemStackInSlot.copy();
+            if (slotIndex == 0) {
+                if (!this.moveItemStackTo(itemStackInSlot, 2, 38, true)) {
+                    return ItemStack.EMPTY;
+                }
+            } else if (slotIndex == 1) {
+                if (!this.moveItemStackTo(itemStackInSlot, 2, 38, true)) {
+                    return ItemStack.EMPTY;
+                }
+            } else if (itemStackInSlot.getItem() == Items.LAPIS_LAZULI) {
+                if (!this.moveItemStackTo(itemStackInSlot, 1, 2, true)) {
+                    return ItemStack.EMPTY;
+                }
+            } else {
+                if (this.slots.get(0).hasItem() || !this.slots.get(0).mayPlace(itemStackInSlot)) {
+                    return ItemStack.EMPTY;
+                }
+
+                ItemStack extractedItemStack = itemStackInSlot.copy();
+                extractedItemStack.setCount(1);
+                itemStackInSlot.shrink(1);
+                this.slots.get(0).set(extractedItemStack);
+            }
+
+            if (itemStackInSlot.isEmpty()) {
+                slot.set(ItemStack.EMPTY);
+            } else {
+                slot.setChanged();
+            }
+
+            if (itemStackInSlot.getCount() == holderItemStack.getCount()) {
+                return ItemStack.EMPTY;
+            }
+
+            slot.onTake(player, itemStackInSlot);
+        }
+
+        return holderItemStack;
+    }
+
+}

--- a/src/main/java/com/nuggylib/enchantmentsseer/common/registries/EnchantmentsSeerContainerTypes.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/registries/EnchantmentsSeerContainerTypes.java
@@ -1,18 +1,19 @@
 package com.nuggylib.enchantmentsseer.common.registries;
 
-/**
- * Inspired by Mekanism code
- *
- * @see "https://github.com/mekanism/Mekanism/blob/v10.1/src/main/java/mekanism/common/registries/MekanismContainerTypes.java"
- */
+import com.nuggylib.enchantmentsseer.common.EnchantmentsSeer;
+import com.nuggylib.enchantmentsseer.common.inventory.container.SeersEnchantingTableContainer;
+import net.minecraft.inventory.container.ContainerType;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
 public class EnchantmentsSeerContainerTypes {
 
     private EnchantmentsSeerContainerTypes() {
-
     }
 
-//    public static final ContainerTypeDeferredRegister CONTAINER_TYPES = new ContainerTypeDeferredRegister(EnchantmentsSeer.MOD_ID);
-//
-//    public static final ContainerTypeRegistryObject<EnchantmentsSeerTileContainer<TileEntitySeersEnchantmentTable>> SEERS_ENCHANTING_TABLE = CONTAINER_TYPES.register(EnchantmentsSeerBlocks.SEERS_ENCHANTING_TABLE, TileEntitySeersEnchantmentTable.class);
+    public static final DeferredRegister<ContainerType<?>> CONTAINER_TYPES = DeferredRegister.create(ForgeRegistries.CONTAINERS, EnchantmentsSeer.MOD_ID);
+
+    public static final RegistryObject<ContainerType<SeersEnchantingTableContainer>> SEERS_ENCHANTING_TABLE = CONTAINER_TYPES.register("seers_enchanting_table", () -> new ContainerType<>(SeersEnchantingTableContainer::new));
 
 }

--- a/src/main/java/com/nuggylib/enchantmentsseer/common/tile/SeersEnchantingTableTileEntity.java
+++ b/src/main/java/com/nuggylib/enchantmentsseer/common/tile/SeersEnchantingTableTileEntity.java
@@ -1,23 +1,65 @@
 package com.nuggylib.enchantmentsseer.common.tile;
 
 import com.nuggylib.enchantmentsseer.common.registries.EnchantmentsSeerTileEntityTypes;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityType;
+import net.minecraft.util.INameable;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 import net.minecraft.tileentity.EnchantingTableTileEntity;
+
+import javax.annotation.Nullable;
+import java.util.Random;
 
 /**
  * Our version of the {@link EnchantingTableTileEntity}
  *
  * @see "https://mcforge.readthedocs.io/en/1.16.x/datastorage/capabilities/#forge-provided-capabilities"
  */
-public class SeersEnchantingTableTileEntity extends TileEntity implements IItemHandler {
+public class SeersEnchantingTableTileEntity extends TileEntity implements IItemHandler, INameable, ITickableTileEntity {
+    public int time;
+    public float flip;
+    public float oFlip;
+    public float flipT;
+    public float flipA;
+    public float open;
+    public float oOpen;
+    public float rot;
+    public float oRot;
+    public float tRot;
+    private static final Random RANDOM = new Random();
+    private ITextComponent name;
 
     public SeersEnchantingTableTileEntity() {
         super(EnchantmentsSeerTileEntityTypes.SEERS_ENCHANTING_TABLE.get());
     }
+
+    // TODO: Vanilla uses save/load presumably to save contents (maybe) - it seems we need to use insertItem/extractItem since we have to go through IItemHandler
+//    @Override
+//    public CompoundNBT save(CompoundNBT nbtTags) {
+//        super.save(nbtTags);
+//        if (this.hasCustomName()) {
+//            nbtTags.putString("CustomName", ITextComponent.Serializer.toJson(this.name));
+//        }
+//
+//        return nbtTags;
+//    }
+//
+//    @Override
+//    public void load(BlockState blockState, CompoundNBT nbtTags) {
+//        super.load(blockState, nbtTags);
+//        if (nbtTags.contains("CustomName", 8)) {
+//            this.name = ITextComponent.Serializer.fromJson(nbtTags.getString("CustomName"));
+//        }
+//
+//    }
 
     @Override
     public int getSlots() {
@@ -50,5 +92,72 @@ public class SeersEnchantingTableTileEntity extends TileEntity implements IItemH
     @Override
     public boolean isItemValid(int slot, @NotNull ItemStack stack) {
         return false;
+    }
+
+    @Override
+    public void tick() {
+        this.oOpen = this.open;
+        this.oRot = this.rot;
+        PlayerEntity playerentity = this.level.getNearestPlayer((double)this.worldPosition.getX() + 0.5D, (double)this.worldPosition.getY() + 0.5D, (double)this.worldPosition.getZ() + 0.5D, 3.0D, false);
+        if (playerentity != null) {
+            double d0 = playerentity.getX() - ((double)this.worldPosition.getX() + 0.5D);
+            double d1 = playerentity.getZ() - ((double)this.worldPosition.getZ() + 0.5D);
+            this.tRot = (float) MathHelper.atan2(d1, d0);
+            this.open += 0.1F;
+            if (this.open < 0.5F || RANDOM.nextInt(40) == 0) {
+                float f1 = this.flipT;
+
+                do {
+                    this.flipT += (float)(RANDOM.nextInt(4) - RANDOM.nextInt(4));
+                } while(f1 == this.flipT);
+            }
+        } else {
+            this.tRot += 0.02F;
+            this.open -= 0.1F;
+        }
+
+        while(this.rot >= (float)Math.PI) {
+            this.rot -= ((float)Math.PI * 2F);
+        }
+
+        while(this.rot < -(float)Math.PI) {
+            this.rot += ((float)Math.PI * 2F);
+        }
+
+        while(this.tRot >= (float)Math.PI) {
+            this.tRot -= ((float)Math.PI * 2F);
+        }
+
+        while(this.tRot < -(float)Math.PI) {
+            this.tRot += ((float)Math.PI * 2F);
+        }
+
+        float f2;
+        for(f2 = this.tRot - this.rot; f2 >= (float)Math.PI; f2 -= ((float)Math.PI * 2F)) {
+        }
+
+        while(f2 < -(float)Math.PI) {
+            f2 += ((float)Math.PI * 2F);
+        }
+
+        this.rot += f2 * 0.4F;
+        this.open = MathHelper.clamp(this.open, 0.0F, 1.0F);
+        ++this.time;
+        this.oFlip = this.flip;
+        float f = (this.flipT - this.flip) * 0.4F;
+        float f3 = 0.2F;
+        f = MathHelper.clamp(f, -0.2F, 0.2F);
+        this.flipA += (f - this.flipA) * 0.9F;
+        this.flip += this.flipA;
+    }
+
+    @Override
+    public ITextComponent getName() {
+        return (ITextComponent)(this.name != null ? this.name : new TranslationTextComponent("container.enchant"));
+    }
+
+    @Nullable
+    public ITextComponent getCustomName() {
+        return this.name;
     }
 }


### PR DESCRIPTION
# Description

**This is a crucial PR, though it _does not complete the Seer's Enchanting Table block setup_.**

This PR adds the following:
1. Registers some stuff:
    1. Seer's Enchanting Table screen (in `com.nuggylib.enchantmentsseer.client.ClientRegistration`)
    2. Seer's Enchanting Container
2. Created the Seer's Enchanting Table screen (`SeersEnchantingTableScreen`)
3. Create a custom Enchantment helper class (`EnchantmentsSeerEnchantHelper`)
4. Added the `use` action to the Seer's Enchanting Table block (controls opening the GUI)
    * See: https://mcforge.readthedocs.io/en/1.16.x/blocks/interaction/#guis
5. Added the container class for the Seer's Enchanting Table - _required for blocks with GUIs and internal storage_
6. More modifications to the Seer's Enchanting Table tile entity class